### PR TITLE
SearchApi tools - return error message instead of an error.

### DIFF
--- a/api/core/tools/provider/builtin/searchapi/tools/google.py
+++ b/api/core/tools/provider/builtin/searchapi/tools/google.py
@@ -45,7 +45,7 @@ class SearchAPI:
     def _process_response(res: dict, type: str) -> str:
         """Process response from SearchAPI."""
         if "error" in res:
-            raise ValueError(f"Got error from SearchApi: {res['error']}")
+            return res["error"]
 
         toret = ""
         if type == "text":

--- a/api/core/tools/provider/builtin/searchapi/tools/google_jobs.py
+++ b/api/core/tools/provider/builtin/searchapi/tools/google_jobs.py
@@ -45,7 +45,7 @@ class SearchAPI:
     def _process_response(res: dict, type: str) -> str:
         """Process response from SearchAPI."""
         if "error" in res:
-            raise ValueError(f"Got error from SearchApi: {res['error']}")
+            return res["error"]
 
         toret = ""
         if type == "text":

--- a/api/core/tools/provider/builtin/searchapi/tools/google_news.py
+++ b/api/core/tools/provider/builtin/searchapi/tools/google_news.py
@@ -45,7 +45,7 @@ class SearchAPI:
     def _process_response(res: dict, type: str) -> str:
         """Process response from SearchAPI."""
         if "error" in res:
-            raise ValueError(f"Got error from SearchApi: {res['error']}")
+            return res["error"]
 
         toret = ""
         if type == "text":

--- a/api/core/tools/provider/builtin/searchapi/tools/youtube_transcripts.py
+++ b/api/core/tools/provider/builtin/searchapi/tools/youtube_transcripts.py
@@ -45,7 +45,7 @@ class SearchAPI:
     def _process_response(res: dict) -> str:
         """Process response from SearchAPI."""
         if "error" in res:
-            raise ValueError(f"Got error from SearchApi: {res['error']}")
+            return res["error"]
 
         toret = ""
         if "transcripts" in res and "text" in res["transcripts"][0]:


### PR DESCRIPTION
# Summary

Instead of raising a `ValueError` with the message `Got error from SearchApi: {res['error']}`, the SearchApi now directly returns the `res['error']` message. This message provides more specific information, such as `YouTube Transcripts didn't return any results.`. This change was implemented in response to customer complaints.

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

